### PR TITLE
Fixed a bug in the default value evaluation

### DIFF
--- a/sbpl/__init__.py
+++ b/sbpl/__init__.py
@@ -190,7 +190,9 @@ class LabelGenerator:
         '2:5': 'BD' # NW-7/CODE39/itf/JAN-13/JAN-8/Code 2 of 5/Matrix 2 of 5/UPC-A
     }
 
-    def __init__(self,packets=bytearray()):
+    def __init__(self, packets=None):
+        if packets is None:
+	    packets = bytearray()
         self._packets = packets
 
     def extend_str(self, tp):
@@ -237,7 +239,7 @@ class LabelGenerator:
             gen.somemethod() # generate inner packets
         """
         class PacketGather:
-            generator = None
+            _generator = None
             def __init__(self, g):
                 self._generator = g
             def __enter__(self):


### PR DESCRIPTION
Fixed a bug that could not be printed multiple times.

When created a LabelGenerator instance for the second or later time, the value of _packets were unexpected.
The reason is that default parameters are not initialized properly.

See here for details: https://docs.python.org/3.9/reference/compound_stmts.html#function-definitions
> if the function modifies the object (e.g. by appending an item to a list), the default value is in effect modified.


Thank you for your a great module. 😄 ❤️ 